### PR TITLE
Feature/form accessibility

### DIFF
--- a/disco/boxes/boxes.php
+++ b/disco/boxes/boxes.php
@@ -88,12 +88,12 @@
 		*
 		* @todo Add a way to indicate that an element is required if $use_label is false.
 		*/
-		function row_open( $label, $required = false, $error = false, $key = false, $use_label = true ) // {{{
+		function row_open( $label, $required = false, $error = false, $key = false, $use_label = true, $label_target_id = false ) // {{{
 		{
-			$this->box_item_open( $label, $required, $error, $key, $use_label );
+			$this->box_item_open( $label, $required, $error, $key, $use_label, $label_target_id );
 		} // }}}
 		
-		function box_item_open( $label, $required, $error, $key, $use_label )
+		function box_item_open( $label, $required, $error, $key, $use_label, $label_target_id = false )
 		{
 			$id = str_replace("_", "", $key);
 			
@@ -115,10 +115,14 @@
 			$markup .= '<a name="'.$key.'_error"></a>'."\n";
 			if($use_label)
 			{
+				if(!empty($label_target_id))
+					$markup .= '<label for="'.htmlspecialchars($label_target_id).'">';
 				if(!empty($stripped_label)) 
 					$markup  .= '<span class="labelText">'.$label.$label_punct.'</span>';
 				if($required) 
 					$markup .= '<span class="requiredIndicator">'.$this->get_required_indicator().'</span>';
+				if(!empty($label_target_id))
+					$markup .= '</label>';
 			}
 			$markup .= '</td>'."\n";
 			$markup .= '<td align="left" class="element">'."\n";
@@ -150,9 +154,9 @@
 		* @param boolean $use_label Whether or not the label should be displayed (optional - default true)
 		* @deprecated this is no longer used as far as I can tell
 		*/
-		function row( $label, $content, $required = false, $error = false, $key = false, $use_label = true) // {{{
+		function row( $label, $content, $required = false, $error = false, $key = false, $use_label = true, $label_target_id = false) // {{{
 		{
-			$this->box_item_open( $label, $required, $error, $key, $use_label);
+			$this->box_item_open( $label, $required, $error, $key, $use_label, $label_target_id);
 			echo $content;
 			$this->box_item_close();
 		} // }}}

--- a/disco/boxes/linear.php
+++ b/disco/boxes/linear.php
@@ -55,7 +55,7 @@
 			echo '<div id="discoLinear">'."\n";
 		} // }}}
 		
-		function box_item_open( $label, $required, $error, $key, $use_label )
+		function box_item_open( $label, $required, $error, $key, $use_label, $label_target_id = false )
 		{
 			$id = str_replace("_", "", $key);
 			
@@ -77,10 +77,14 @@
 			$markup .= '<a name="'.$key.'_error"></a>'."\n";
 			if($use_label)
 			{
+				if(!empty($label_target_id))
+					$markup .= '<label for="'.htmlspecialchars($label_target_id).'">';
 				if(!empty($stripped_label)) 
 					$markup  .= $label.$label_punct;
 				if($required) 
 					$markup .= '*';
+				if(!empty($label_target_id))
+					$markup .= '</label>';
 			}
 			$markup .= '</span>'."\n";
 			echo $markup;	

--- a/disco/boxes/stacked.php
+++ b/disco/boxes/stacked.php
@@ -24,7 +24,7 @@ class StackedBox extends Box // {{{
 		echo '<div id="discoLinear">'."\n";
 	} // }}}
 	
-	function box_item_open( $label, $required, $error, $key, $use_label )
+	function box_item_open( $label, $required, $error, $key, $use_label, $label_target_id = false )
 	{
 		$id = str_replace("_", "", $key);
 		
@@ -47,10 +47,14 @@ class StackedBox extends Box // {{{
 		$markup .= '<div class="words">';
 		if($use_label)
 		{
+			if(!empty($label_target_id))
+				$markup .= '<label for="'.htmlspecialchars($label_target_id).'">';
 			if(!empty($stripped_label)) 
 				$markup  .= '<span class="labelText">'.$label.'</span>';
 			if($required) 
 				$markup .= '<span class="requiredIndicator">'.$this->get_required_indicator().'</span>';
+			if(!empty($label_target_id))
+				$markup .= '</label>';
 		}
 		$markup .= '</div>'."\n";
 		$markup .= '<div class="element">'."\n";

--- a/disco/disco.php
+++ b/disco/disco.php
@@ -1115,11 +1115,14 @@
 		*/
 		function show_normal_element( $element_name , $element , &$b) // {{{
 		{
-			$b->row_open( $this->get_display_name($element_name), 
-						  $this->is_required( $element_name ), 
-						  $this->has_error( $element_name ), 
-						  $element_name, 
-						  $this->get_element_property($element_name, 'use_display_name') );
+			$b->row_open(
+						  $this->get_display_name($element_name),
+						  $this->is_required( $element_name ),
+						  $this->has_error( $element_name ),
+						  $element_name,
+						  $this->get_element_property($element_name, 'use_display_name'),
+						  $this->get_label_target_id( $element_name )
+			);
 			
 			// drop in a named anchor for error jumping
 			// echo '<a name="'.$element_name.'_error"></a>'."\n";
@@ -2393,6 +2396,16 @@
 				trigger_error('Cannot set error, as '.$element_name.' is not a recognized element or element group', WARNING);
 			}
 		} // }}}
+		
+		function get_label_target_id( $element_name )
+		{
+			if($this->_is_element($element_name))
+			{
+				$element = $this->get_element($element_name);
+				return $element->get_label_target_id();
+			}
+			return false;
+		}
 		
 	//////////////////////////////////////////////////
 	// MISC. METHODS

--- a/disco/plasmature/types/checkbox.php
+++ b/disco/plasmature/types/checkbox.php
@@ -38,23 +38,41 @@ class checkboxType extends defaultType
 	}
 	function get_display()
 	{
-		$this->checkbox_id = 'checkbox_'.$this->name;
-		$str = '<input type="checkbox" id="'.htmlspecialchars($this->checkbox_id).'" name="'.htmlspecialchars($this->name).'" value="'.htmlspecialchars($this->checked_value).'"';
+		
+		$str = '<input type="checkbox" id="'.htmlspecialchars($this->get_checkbox_id()).'" name="'.htmlspecialchars($this->name).'" value="'.htmlspecialchars($this->checked_value).'"';
 		if ( $this->value )
 		{
 			$str .= ' checked="checked"';
 		}
+		if( $this->use_aria_label() )
+		{
+			$str .= ' aria-label="'.htmlspecialchars($this->display_name).'"';
+		}
 		$str .= ' class="checkbox" />';
 		if (!empty($this->description)) {
-			$str .= ' <label class="smallText" for="'.htmlspecialchars($this->checkbox_id).'">'.$this->description.'</label>';
+			$str .= ' <label class="smallText" for="'.htmlspecialchars($this->get_checkbox_id()).'">'.$this->description.'</label>';
 		}
 		return $str;
+	}
+	
+	function use_aria_label()
+	{
+		return (empty($this->description) && !$this->is_labeled());
+	}
+	
+	function get_checkbox_id()
+	{
+		if(empty($this->checkbox_id))
+			$this->checkbox_id = 'checkbox_'.$this->name;
+		return $this->checkbox_id;
 	}
 	
 	function get_label_target_id()
 	{
 		if (empty($this->description)) // If there is no description the element is labeled by the display name
-			return $this->checkbox_id;
+		{
+			return $this->get_checkbox_id();
+		}
 		return false; // Otherwise it is labeled by the description
 	}
 }
@@ -84,6 +102,14 @@ class checkboxfirstType extends checkboxType {
 	
 	function get_display()
 	{
-		return parent::get_display().' <label for="'.htmlspecialchars($this->checkbox_id).'">'.$this->display_name.'</label>';
+		return parent::get_display().' <label for="'.htmlspecialchars($this->get_checkbox_id()).'">'.$this->display_name.'</label>';
+	}
+	
+	/**
+	 * Since we are using a <label> element we should not use an aria label
+	 */
+	function use_aria_label()
+	{
+		return false;
 	}
 }

--- a/disco/plasmature/types/checkbox.php
+++ b/disco/plasmature/types/checkbox.php
@@ -113,3 +113,11 @@ class checkboxfirstType extends checkboxType {
 		return false;
 	}
 }
+
+/**
+ * Like {@link checkboxType}, but does not display a label
+ */
+class checkbox_no_labelType extends checkboxType {
+	var $type = 'checkbox_no_label';
+	var $_labeled = false;
+}

--- a/disco/plasmature/types/checkbox.php
+++ b/disco/plasmature/types/checkbox.php
@@ -39,16 +39,23 @@ class checkboxType extends defaultType
 	function get_display()
 	{
 		$this->checkbox_id = 'checkbox_'.$this->name;
-		$str = '<input type="checkbox" id="'.$this->checkbox_id.'" name="'.$this->name.'" value="'.$this->checked_value.'"';
+		$str = '<input type="checkbox" id="'.htmlspecialchars($this->checkbox_id).'" name="'.htmlspecialchars($this->name).'" value="'.htmlspecialchars($this->checked_value).'"';
 		if ( $this->value )
 		{
 			$str .= ' checked="checked"';
 		}
 		$str .= ' class="checkbox" />';
 		if (!empty($this->description)) {
-			$str .= ' <label class="smallText" for="'.$this->checkbox_id.'">'.$this->description.'</label>';
+			$str .= ' <label class="smallText" for="'.htmlspecialchars($this->checkbox_id).'">'.$this->description.'</label>';
 		}
 		return $str;
+	}
+	
+	function get_label_target_id()
+	{
+		if (empty($this->description)) // If there is no description the element is labeled by the display name
+			return $this->checkbox_id;
+		return false; // Otherwise it is labeled by the description
 	}
 }
 
@@ -77,6 +84,6 @@ class checkboxfirstType extends checkboxType {
 	
 	function get_display()
 	{
-		return parent::get_display().' <label for="'.$this->checkbox_id.'">'.$this->display_name.'</label>';
+		return parent::get_display().' <label for="'.htmlspecialchars($this->checkbox_id).'">'.$this->display_name.'</label>';
 	}
 }

--- a/disco/plasmature/types/colorpicker.php
+++ b/disco/plasmature/types/colorpicker.php
@@ -125,5 +125,9 @@ class colorpickerType extends defaultType
 		return $str;
 	}	
 	
+	function get_label_target_id()
+	{
+		return $this->name;
+	}
 }
 ?>

--- a/disco/plasmature/types/datetime.php
+++ b/disco/plasmature/types/datetime.php
@@ -168,6 +168,15 @@ class textDateTimeType extends textType
 		'second',
 		'ampm',
 	);
+	var $id_suffixes = array(
+		'year' => '',
+		'month' => 'mm',
+		'day' => 'dd',
+		'hour' => 'HH',
+		'minute' => 'MM',
+		'second' => 'SS',
+		'ampm' => 'ampmElement',
+	);
 	/**
 	 *  Sets the value to the current datetime if the value is empty and {@link prepopulate} is set.
 	 */
@@ -364,6 +373,17 @@ class textDateTimeType extends textType
 	function get_display()
 	{
 		$str = '';
+		
+		$before = '';
+		$after = '';
+		if(count($this->use_fields) > 1)
+		{
+			$before = '<span role="group" aria-label=
+		"'.htmlspecialchars($this->display_name).'">';
+			$after = '</span>';
+		}
+		
+		$str .= $before;
 		foreach($this->use_fields as $field_name)
 		{
 			$get_val_method = 'get_'.$field_name.'_value_for_display';
@@ -377,6 +397,7 @@ class textDateTimeType extends textType
 			else
 				trigger_error($field_name.' is in $use_fields, but no display method exists for it');
 		}
+		$str .= $after;
 		return $str;
 	}
 	function get_value_for_month_display()
@@ -407,53 +428,51 @@ class textDateTimeType extends textType
 			$h = $this->hour;
 		$str .= $this->get_hour_display($h);
 	}
-	function _get_display($name, $value, $id_suffix, $separator='', $size=2,
+	function _get_display($name, $value, $separator='', $size=2,
 	    $class=null)
 	{
 	    $class = ($class)
 	        ? ' class="'.$class.'"'
 	        : '';
-	    $id = $this->name;
-	    if ($id_suffix)
-	        $id .= "-$id_suffix";
 	    $value = htmlspecialchars($value, ENT_QUOTES);
 	    return $separator.'<input type="text"'.$class.' size="'.$size.'" '.
-	        'maxlength="'.$size.'" id="'.$id.'" '.
-	        'name="'.$this->name.'['.$name.']" value="'.$value.'" />';
+	        'maxlength="'.$size.'" id="'.htmlspecialchars($this->get_field_id($name)).'" '.
+	        'name="'.$this->name.'['.$name.']" value="'.htmlspecialchars($value).'" aria-label="'.htmlspecialchars($name).' ('.htmlspecialchars($size).' digits)" />';
 	}
+	
 	function get_month_display($month_val = '')
 	{
-	    return $this->_get_display('month', $month_val, 'mm');
+	    return $this->_get_display('month', $month_val);
 	}
 	function get_day_display($day_val = '')
 	{
-	    return $this->_get_display('day', $day_val, 'dd', ' / ');
+	    return $this->_get_display('day', $day_val, ' / ');
 	}
 	function get_year_display($year_val = '')
 	{
 	    // The classes on the year display activate the JavaScript
 	    // date picker.
 	    $class = ($this->use_picker) ? 'datepicker' : null;
-		return $this->_get_display('year', $year_val, null, ' / ', 4,
+		return $this->_get_display('year', $year_val, ' / ', 4,
 		    $class);
 	}
 	function get_hour_display($hour_val = '')
 	{
-		return $this->_get_display('hour', $hour_val, 'HH',
+		return $this->_get_display('hour', $hour_val, 
 		    '<span class="datetimeAt">&nbsp;&nbsp; at ');
 	}
 	function get_minute_display($minute_val = '')
 	{
-	    return $this->_get_display('minute', $minute_val, 'MM', ' : ');
+	    return $this->_get_display('minute', $minute_val, ' : ');
 	}
 	function get_second_display($second_val = '')
 	{
-		return $this->_get_display('second', $second_val, 'SS', ' : ');
+		return $this->_get_display('second', $second_val, ' : ');
 	}
 	function get_ampm_display($ampm_val)
 	{
 		$str = ' ';
-		$str .= '<select id="'.$this->name.'ampmElement" name="'.$this->name.'[ampm]">';
+		$str .= '<select id="'.$this->name.'ampmElement" name="'.$this->name.'[ampm]" aria-label="AM or PM">';
 		$str .= '<option value="am"'.($ampm_val == 'am' ? ' selected="selected"': '').'>AM</option>';
 		$str .= '<option value="pm"'.($ampm_val == 'pm' ? ' selected="selected"': '').'>PM</option>';
 		$str .= '</select></span>';
@@ -462,6 +481,26 @@ class textDateTimeType extends textType
 	function get_cleanup_rules()
 	{
 		return array( $this->name => array( 'function' => 'turn_into_array' ));
+	}
+	function get_label_target_id()
+	{
+		if(count($this->use_fields) == 1)
+		{
+			$field = current($this->use_fields);
+			if($id = $this->get_field_id($field))
+				return $id;
+		}
+		return false;
+	}
+	function get_field_id($field)
+	{
+		if(isset($this->id_suffixes[$field]))
+		{
+			if(!empty($this->id_suffixes[$field]))
+				return $this->name.'-'.$this->id_suffixes[$field];
+			return $this->name;
+		}
+		return NULL;
 	}
  }
 

--- a/disco/plasmature/types/datetime.php
+++ b/disco/plasmature/types/datetime.php
@@ -61,6 +61,10 @@ class monthType extends selectType
 		}
 	}
 }
+class month_no_labelType extends monthType
+{
+	var $_labeled = false;
+}
 
 /**
  * Presents a drop-down of years.
@@ -118,6 +122,11 @@ class yearType extends numrangeType
 			$this->end = $current_date['year'] + $this->num_years_after_today;
 		}
 	 }
+}
+
+class year_no_labelType extends yearType
+{
+	var $_labeled = false;
 }
 
 /**
@@ -355,7 +364,7 @@ class textDateTimeType extends textType
 
 	function display()
 	{
-	    if ($this->use_picker && !defined("DATE_PICKER_HEAD_ITEMS_LOADED") && !defined('_PLASMATURE_INCLUDED_DATEPICKER'))
+	    if ($this->use_picker && !defined("DATE_PICKER_HEAD_ITEMS_LOADED") && !defined('_PLASMATURE_INCLUDED_DATEPICKER') && defined('REASON_HTTP_BASE_PATH') )
 	    {
 	        /**
 	         * We specify the english datepicker .js file ... the dynamic mechanism to pick the language
@@ -569,9 +578,10 @@ class selectMonthTextYearType extends textDateTimeType
 	function init_month_element()
 	{
 		//set up the month plasmature element
-		$this->month_element = new monthType;
+		$this->month_element = new month_no_labelType;
 		$this->month_element->set_request( $this->_request );
 		$this->month_element->set_name( $this->name.'[month]' );
+		$this->month_element->set_display_name( 'month' );
 		if(empty($this->month_args['date_format']))
 			$this->month_args['date_format'] = 'F';
 		$this->month_element->init($this->month_args);
@@ -624,8 +634,9 @@ class selectMonthYearType extends selectMonthTextYearType
 	function init_year_element()
 	{
 		//set up the year plasmature element
-		$this->year_element = new yearType;
+		$this->year_element = new year_no_labelType;
 		$this->year_element->set_request( $this->_request );
+		$this->year_element->set_display_name('year');
 		$this->year_element->set_name( $this->name.'[year]' );
 		if(empty($this->year_args['end']) || (isset($this->year_args['end']) && $this->year_args['end'] > $this->year_max))
 			$this->year_args['end'] = $this->year_max;

--- a/disco/plasmature/types/default.php
+++ b/disco/plasmature/types/default.php
@@ -740,4 +740,9 @@ class defaultType
 		}
 		return $this->_labeled;
 	}
+	
+	function get_label_target_id()
+	{
+		return false;
+	}
 }

--- a/disco/plasmature/types/default.php
+++ b/disco/plasmature/types/default.php
@@ -740,7 +740,26 @@ class defaultType
 		}
 		return $this->_labeled;
 	}
-	
+	/**
+	 * Get an ID to use as the for="" attribute on the display name label produced by Disco
+	 *
+	 * Plasmature elements should assume that if this is returning a nonfalse value,
+	 * Disco's box class will put a label element using this value as the for="" attribute
+	 * around the display name.
+	 *
+	 * If the element is not labeled (That is, @is_labeled() returns false), the plasmature
+	 * element should use other means of labeling the element for accessibility, like
+	 * using the aria-label attribute.
+	 *
+	 * In some cases (e.g. Plasmature elements that use multiple inputs, like checkbox groups,
+	 * radio buttons, and some date/time elements) there is no single input to label.
+	 * In these cases, the plasmature element should return false for this method and should
+	 * instead self-label. Best practices as of 2016 are to produce a wrapper element with
+	 * role="group" and aria-label="[[display_name]]", and to produce label elements or use
+	 * aria-label on each component input.
+	 *
+	 * @return mixed false if no label is appropriate, string if label is desired
+	 */
 	function get_label_target_id()
 	{
 		return false;

--- a/disco/plasmature/types/formbuilder.php
+++ b/disco/plasmature/types/formbuilder.php
@@ -33,4 +33,10 @@ class formbuilderType extends textareaType
 <?php
 
 	}
+	
+	// Not sure how to label this tool for accessibility
+	function get_label_target_id()
+	{
+		return false;
+	}
 }

--- a/disco/plasmature/types/html5.php
+++ b/disco/plasmature/types/html5.php
@@ -18,7 +18,6 @@ class telType extends defaultTextType
 {
 	var $type = 'tel';
 
-	
 	function get_display()
 	{
 		$str  = '<input type="tel" name="'.$this->name.'" id="'.$this->get_id().'" value="'.htmlspecialchars($this->get(),ENT_QUOTES).'"/>';
@@ -37,6 +36,11 @@ class telType extends defaultTextType
 			}
 		}
 		parent::grab();
+	}
+	
+	function get_label_target_id()
+	{
+		return $this->get_id();
 	}
 }
 
@@ -67,6 +71,11 @@ class numberType extends defaultTextType
 		$str .= '/>'; 
 		return $str;
 	}
+	
+	function get_label_target_id()
+	{
+		return $this->get_id();
+	}
 }
 
 /**
@@ -96,6 +105,11 @@ class rangeType extends defaultTextType
 		}
 		$str .= '/>';
 		return $str;
+	}
+	
+	function get_label_target_id()
+	{
+		return $this->get_id();
 	}
 }
 

--- a/disco/plasmature/types/options.php
+++ b/disco/plasmature/types/options.php
@@ -843,7 +843,10 @@ class selectType extends optionType
 	function get_display()
 	{
 		//pray($this->value);
-		$str = '<select id="'.htmlspecialchars($this->get_label_target_id()).'" name="'.$this->name.($this->multiple ? '[]' : '').'" size="'.htmlspecialchars($this->n, ENT_QUOTES).'" '.($this->multiple ? 'multiple="multiple"' : '').'>'."\n";
+		$str = '<select id="'.htmlspecialchars($this->get_label_target_id()).'" name="'.$this->name.($this->multiple ? '[]' : '').'" size="'.htmlspecialchars($this->n, ENT_QUOTES).'" '.($this->multiple ? 'multiple="multiple"' : '');
+		if(!$this->is_labeled())
+			$str .= ' aria-label="'.htmlspecialchars($this->display_name).'"';
+		$str .= '>'."\n";
 		$select_count = 0;
 		if($this->add_empty_value_to_top)
 		{

--- a/disco/plasmature/types/options.php
+++ b/disco/plasmature/types/options.php
@@ -392,7 +392,8 @@ class radioType extends optionType
 	function get_display()
 	{
 		$i = 0;
-		$str = '<div id="'.$this->name.'_container" class="radioButtons">'."\n";
+		$str = '<div id="'.$this->name.'_container" class="radioButtons" role="group" aria-label=
+		"'.htmlspecialchars($this->display_name).'">'."\n";
 		if (!$this->tableless) $str .= '<table border="0" cellpadding="1" cellspacing="0">'."\n";
 		$checked = false;
 		if($this->add_empty_value_to_top)
@@ -466,11 +467,11 @@ class radioType extends optionType
 
 		if (empty($this->other_options))
 		{
-			$str .= '<input type="text" name="'.$this->name.'_other" value="'.str_replace('"', '&quot;', $other_value).'"  />';
+			$str .= '<input aria-label="'.str_replace(':','',$this->other_label).' (Enter)" type="text" name="'.$this->name.'_other" value="'.str_replace('"', '&quot;', $other_value).'"  />';
 		}
 		else
 		{
-			$str .= '<select name="'.$this->name.'_other" class="other">';
+			$str .= '<select aria-label="'.str_replace(':','',$this->other_label).' (Enter)" name="'.$this->name.'_other" class="other">';
 			foreach($this->other_options as $k => $v)
 			{
 				$selected = ($k == $other_value) ? ' selected="selected"' : '';
@@ -583,7 +584,8 @@ class checkboxgroupType extends optionType
 	}
 	function get_display()
 	{
-		$str = '<div class="checkBoxGroup">'."\n";
+		$str = '<div class="checkBoxGroup" role="group" aria-label=
+		"'.htmlspecialchars($this->display_name).'">'."\n";
 		if (!$this->tableless) $str .= '<table border="0" cellpadding="1" cellspacing="0">'."\n";
 		$i = 0;
 
@@ -841,7 +843,7 @@ class selectType extends optionType
 	function get_display()
 	{
 		//pray($this->value);
-		$str = '<select id="'.$this->name.'Element" name="'.$this->name.($this->multiple ? '[]' : '').'" size="'.htmlspecialchars($this->n, ENT_QUOTES).'" '.($this->multiple ? 'multiple="multiple"' : '').'>'."\n";
+		$str = '<select id="'.htmlspecialchars($this->get_label_target_id()).'" name="'.$this->name.($this->multiple ? '[]' : '').'" size="'.htmlspecialchars($this->n, ENT_QUOTES).'" '.($this->multiple ? 'multiple="multiple"' : '').'>'."\n";
 		$select_count = 0;
 		if($this->add_empty_value_to_top)
 		{
@@ -922,6 +924,11 @@ class selectType extends optionType
 		$rv = array_filter($array,'is_array');
 	    if(count($rv)>0) return true;
 	    return false;
+	}
+	
+	function get_label_target_id()
+	{
+		return $this->name.'Element';
 	}
 }
 
@@ -1198,7 +1205,7 @@ class select_multipleType extends selectType
 		}
 		else
 		{
-			$str = '<select name="'.$this->name.'[]" multiple="multiple" size="'.$this->select_size.'">'."\n";
+			$str = '<select id="'.htmlspecialchars($this->get_label_target_id()).'" name="'.$this->name.'[]" multiple="multiple" size="'.$this->select_size.'">'."\n";
 			$select_count = 0;
 			if($this->add_empty_value_to_top)
 			{
@@ -1240,6 +1247,13 @@ class select_multipleType extends selectType
 		}
 		$str .= '>'.$val.'</option>'."\n";
 		return $str;
+	}
+	
+	function get_label_target_id()
+	{
+		if( $this->multiple_display_type == 'checkbox' )
+			return false;
+		return parent::get_label_target_id();
 	}
 }
 
@@ -1295,7 +1309,10 @@ class range_sliderType extends defaultType
 
 	function get_display()
 	{
-		return '<input type="range" name="'.$this->name.'" value="'.str_replace('"', '&quot;', $this->get()).'"   id="'.$this->name.'Element" min="'.$this->min.'" max="'.$this->max.'" step="'.$this->step.'" />';
+		return '<input type="range" name="'.$this->name.'" value="'.str_replace('"', '&quot;', $this->get()).'"   id="'.htmlspecialchars($this->get_label_target_id()).'" min="'.$this->min.'" max="'.$this->max.'" step="'.$this->step.'" />';
 	}
-
+	function get_label_target_id()
+	{
+		return $this->name.'Element';
+	}
 }

--- a/disco/plasmature/types/text.php
+++ b/disco/plasmature/types/text.php
@@ -71,8 +71,11 @@ class textType extends defaultTextType
 
 	function get_display()
 	{
-		$display = '<input type="text" name="'.$this->name.'" value="'.str_replace('"', '&quot;', $this->get()).'" size="'.$this->size.'" maxlength="'.$this->maxlength.'" id="'.$this->get_id().'" aria-label="'.$this->display_name.'" class="text" ';
-		if (!empty($this->placeholder)) $display .= 'placeholder="'.htmlspecialchars($this->placeholder).'"';
+		$display = '<input type="text" name="'.htmlspecialchars($this->name).'" value="'.htmlspecialchars($this->get()).'" size="'.htmlspecialchars($this->size).'" maxlength="'.htmlspecialchars($this->maxlength).'" id="'.htmlspecialchars($this->get_id()).'" class="text" ';
+		if (!empty($this->placeholder))
+			$display .= 'placeholder="'.htmlspecialchars($this->placeholder).'" ';
+		if(!$this->is_labeled())
+			$display .= 'aria-label="'.htmlspecialchars($this->display_name).'" ';
 		$display .= '/>';
 		return $display;
 	}
@@ -172,7 +175,10 @@ class disabledTextType extends textType
 	}
 	function get_display()
 	{
-		$str  = '<input type="text" name="'.$this->name.'" id="'.$this->get_id().'" value="'.htmlspecialchars($this->get(),ENT_QUOTES).'" size="'.$this->size.'" maxlength="'.$this->maxlength.'" disabled="disabled" />';
+		$str  = '<input type="text" name="'.htmlspecialchars($this->name).'" id="'.htmlspecialchars($this->get_id()).'" value="'.htmlspecialchars($this->get(),ENT_QUOTES).'" size="'.htmlspecialchars($this->size).'" maxlength="'.htmlspecialchars($this->maxlength).'" disabled="disabled" ';
+		if(!$this->is_labeled())
+			$str .= 'aria-label="'.htmlspecialchars($this->display_name).'" ';
+		$str .= '/>';
 		return $str;
 	}
 }
@@ -189,8 +195,11 @@ class passwordType extends defaultTextType
 	var $type_valid_args = array( 'size', 'maxlength', 'placeholder' );
 	function get_display()
 	{
-		$display = '<input type="password" name="'.$this->name.'" id="'.$this->get_id().'" value="'.htmlspecialchars($this->get(),ENT_QUOTES).'" size="'.$this->size.'" maxlength="'.$this->maxlength.'" aria-label="'.$this->display_name.'" ';
-		if (!empty($this->placeholder)) $display .= 'placeholder="'.$this->placeholder.'"';
+		$display = '<input type="password" name="'.htmlspecialchars($this->name).'" id="'.htmlspecialchars($this->get_id()).'" value="'.htmlspecialchars($this->get(),ENT_QUOTES).'" size="'.htmlspecialchars($this->size).'" maxlength="'.htmlspecialchars($this->maxlength).'" ';
+		if (!empty($this->placeholder))
+			$display .= 'placeholder="'.htmlspecialchars($this->placeholder).'"';
+		if(!$this->is_labeled())
+			$display .= 'aria-label="'.htmlspecialchars($this->display_name).'" ';
 		$display .= '/>';
 		return $display;
 	}
@@ -242,7 +251,7 @@ class money_solidTextType extends solidtextType
 	var $type_valid_args = array( 'currency_symbol','decimal_symbol' );
 	function get_display()
 	{
-		$str  = '<input type="hidden" name="'.$this->name.'" id="'.$this->get_id().'" value="'.htmlspecialchars($this->get(),ENT_QUOTES).'"/>';
+		$str  = '<input type="hidden" name="'.htmlspecialchars($this->name).'" id="'.$this->get_id().'" value="'.htmlspecialchars($this->get(),ENT_QUOTES).'"/>';
 		$str .= "\n".'<div class="solidText">' . $this->currency_symbol . htmlspecialchars($this->get(),ENT_QUOTES). '</div>';
 		return $str;
 	}
@@ -262,7 +271,7 @@ class money_disabledChangeableType extends defaultTextType
 	var $type_valid_args = array( 'currency_symbol','decimal_symbol' );
 	function get_display()
 	{
-		$str  = '<input type="hidden" name="'.$this->name.'" id="'.$this->get_id().'" value="'.htmlspecialchars($this->get(),ENT_QUOTES).'"/>';
+		$str  = '<input type="hidden" name="'.htmlspecialchars($this->name).'" id="'.$this->get_id().'" value="'.htmlspecialchars($this->get(),ENT_QUOTES).'"/>';
 		$str .= "\n".'<div class="solidText">' . $this->currency_symbol . htmlspecialchars($this->get(),ENT_QUOTES). '</div>';
 		return $str;
 	}
@@ -280,7 +289,10 @@ class textareaType extends defaultTextType
 	var $type_valid_args = array('rows', 'cols');
 	function get_display()
 	{
-		$str  = '<textarea name="'.$this->name.'" id="'.$this->get_id().'" aria-label="'.$this->display_name.'" rows="'.$this->rows.'" cols="'.$this->cols.'">'.htmlspecialchars($this->get(),ENT_QUOTES,'UTF-8').'</textarea>';
+		$str  = '<textarea name="'.htmlspecialchars($this->name).'" id="'.htmlspecialchars($this->get_id()).'" rows="'.htmlspecialchars($this->rows).'" cols="'.htmlspecialchars($this->cols).'"';
+		if(!$this->is_labeled())
+			$str .= ' aria-label="'.htmlspecialchars($this->display_name).'"';
+		$str .= '>'.htmlspecialchars($this->get(),ENT_QUOTES,'UTF-8').'</textarea>';
 		return $str;
 	}
 	function grab()
@@ -341,7 +353,10 @@ class wysiwyg_disabledType extends textareaType
 
 	function get_display()
 	{
-		$str  = '<textarea name="'.htmlspecialchars($this->name, ENT_QUOTES).'" rows="'.$this->rows.'" cols="'.$this->cols.'" id="'.$this->get_id().'" disabled="disabled" >'.htmlspecialchars($this->get(),ENT_QUOTES,'UTF-8').'</textarea>';
+		$str = '<textarea name="'.htmlspecialchars($this->name, ENT_QUOTES).'" rows="'.htmlspecialchars($this->rows).'" cols="'.htmlspecialchars($this->cols).'" id="'.htmlspecialchars($this->get_id()).'" disabled="disabled"';
+		if(!$this->is_labeled())
+			$str .= ' aria-label="'.htmlspecialchars($this->display_name).'"';
+		$str .= '>'.htmlspecialchars($this->get(),ENT_QUOTES,'UTF-8').'</textarea>';
 		$str .= $this->_get_javascript_block($this->get_id());
 		return $str;
 	}
@@ -349,7 +364,7 @@ class wysiwyg_disabledType extends textareaType
 	function get_id()
 	{
 		if (empty($this->id))
-			return htmlspecialchars($this->name.'_"_area', ENT_QUOTES);
+			return $this->name.'_area';
 		else
 			return $this->id;
 	}
@@ -392,7 +407,7 @@ class wysiwyg_solidtextType extends solidtextType
 
 	function get_display()
 	{
-		$str  = '<input type="hidden" name="'.$this->name.'" id="'.$this->get_id().'" value="'.htmlspecialchars($this->get(),ENT_QUOTES).'"/>';
+		$str  = '<input type="hidden" name="'.htmlspecialchars($this->name).'" id="'.htmlspecialchars($this->get_id()).'" value="'.htmlspecialchars($this->get(),ENT_QUOTES).'"/>';
 		$str .= "\n".'<div class="wysiwyg_solidText">' . $this->get(). '</div>';
 		return $str;
 	}

--- a/disco/plasmature/types/text.php
+++ b/disco/plasmature/types/text.php
@@ -72,9 +72,14 @@ class textType extends defaultTextType
 	function get_display()
 	{
 		$display = '<input type="text" name="'.$this->name.'" value="'.str_replace('"', '&quot;', $this->get()).'" size="'.$this->size.'" maxlength="'.$this->maxlength.'" id="'.$this->get_id().'" aria-label="'.$this->display_name.'" class="text" ';
-		if (!empty($this->placeholder)) $display .= 'placeholder="'.$this->placeholder.'"';
+		if (!empty($this->placeholder)) $display .= 'placeholder="'.htmlspecialchars($this->placeholder).'"';
 		$display .= '/>';
 		return $display;
+	}
+	
+	function get_label_target_id()
+	{
+		return $this->get_id();
 	}
 }
 
@@ -189,6 +194,11 @@ class passwordType extends defaultTextType
 		$display .= '/>';
 		return $display;
 	}
+	
+	function get_label_target_id()
+	{
+		return $this->get_id();
+	}
 }
 
 /**
@@ -290,6 +300,11 @@ class textareaType extends defaultTextType
 				$this->set_error( 'There is more text in '.$name_to_display.' than can be stored; this field can hold no more than '.$length_limits[$this->db_type].' characters.' );
 			}
 		}
+	}
+	
+	function get_label_target_id()
+	{
+		return $this->get_id();
 	}
 }
 

--- a/disco/plasmature/types/upload.php
+++ b/disco/plasmature/types/upload.php
@@ -797,11 +797,23 @@ class uploadType extends defaultType
 		}
 		
 		$upload = '<div class="file_upload">';
+		$label_id = '';
 		if ($label) {
-			$upload .= '<span class="smallText">'.$label."</span><br />";
+			$label_id = $this->get_id().'AddReplaceDesc';
+			$upload .= '<span class="smallText" id="'.htmlspecialchars($label_id).'">'.$label."</span><br />";
 		}
-		$upload .= '<input type="file" name="'.$this->name.'" /></div>';
+		$upload .= '<input type="file" name="'.htmlspecialchars($this->name).'" id="'.htmlspecialchars($this->get_id()).'" ';
+		if(!empty($label_id))
+			$upload .= 'aria-describedby="'.htmlspecialchars($label_id).'" ';
+		if(!$this->is_labeled())
+			$upload .= 'aria-label="'.htmlspecialchars($this->display_name).'" ';
+		$upload .= '/></div>';
 		return $upload;
+	}
+	
+	function get_label_target_id()
+	{
+		return $this->get_id();
 	}
 }
 

--- a/disco/tests/all_elements_test.php
+++ b/disco/tests/all_elements_test.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @package disco
+ */
+?>
+<html>
+<head>
+<title>Test all Plasmature elements</title>
+<style>
+.formElement {
+	padding:1em;
+}
+</style>
+</head>
+<body>
+<?php
+
+$before_classes = get_declared_classes();
+
+include_once(DISCO_INC.'disco.php');
+$d = new disco();
+$d->set_box_class('stackedBox');
+
+$after_classes = get_declared_classes();
+
+$added = array_diff($after_classes, $before_classes);
+
+$plasmature_types = array();
+$exclude = array(
+	'defaultType',
+	'defaultTextType',
+	'tablelinkerType',
+	'AssetUploadType',
+	'thorType',
+	'optionType',
+	'option_no_sortType',
+);
+foreach($added as $classname)
+{	
+	if(!in_array($classname, $exclude) && ( $pos = strrpos($classname, 'Type') ) )
+	{
+		if($pos = ( strlen($classname) - 4 ) )
+		{
+			if(is_a($classname, 'defaultType', true))
+			{
+				$plasmature_types[] = substr($classname, 0, $pos);
+			}
+		}
+	}
+}
+foreach($plasmature_types as $type)
+{
+	$options = array('' => '--','0' => 'Zero', '1' => 'One');
+	$d->add_element($type, $type);
+	$d->set_value($type, 1);
+	
+	$el = $d->get_element($type);
+	if(is_a($el, 'optionType'))
+	{
+		$d->set_element_properties($type, array('options' => $options) );
+	}
+	elseif(is_a($el, 'checkboxType'))
+	{
+		$d->set_element_properties($type, array('checked_value' => 'checked' ));
+	}
+}
+
+$d->run();
+
+?>
+</body>

--- a/reason_4.0/lib/core/content_managers/blog.php
+++ b/reason_4.0/lib/core/content_managers/blog.php
@@ -94,8 +94,7 @@
 			
 			// Social sharing
 			$this->add_element('social_sharing_comment','comment',array('text'=>'<h4>Social Sharing</h4>'));
-			$this->add_comments('social_sharing_comment',form_comment('Would you like to provide links to share your content on social networks?'));
-			$this->set_display_name('enable_social_sharing','&nbsp;');		
+			$this->set_display_name('enable_social_sharing','Would you like to provide links to share your content on social networks?');		
 			$this->change_element_type('enable_social_sharing', 'radio',array('options' => array('no' => 'Don\'t provide buttons to share posts','yes' => 'Provide buttons to share posts on social networks' )));	
 			if(!$this->get_value('enable_social_sharing'))
 			{

--- a/reason_4.0/lib/core/content_managers/event.php3
+++ b/reason_4.0/lib/core/content_managers/event.php3
@@ -173,7 +173,7 @@
 											'yearly'=>'Yearly'), 
 											'add_empty_value_to_top' => false,
 					) );
-			$this->change_element_type( 'minutes', 'select_no_sort', array('options'=>$minutes) );
+			$this->change_element_type( 'minutes', 'select_no_label', array('options'=>$minutes,'sort_options'=>false) );
 			$this->change_element_type( 'hours', 'select_no_sort', array('options'=>$hours) );
 			$this->change_element_type( 'frequency', 'text', array('size'=>3) );
 			$this->change_element_type( 'week_of_month','protected' );
@@ -201,7 +201,6 @@
 			$this->set_comments(	 'url', form_comment( 'If this event has a site dedicated to it, enter that URL here.' ) );
 			$this->set_display_name( 'hours', 'Duration' );
 			$this->set_comments(	 'hours', ' Hours');
-			$this->set_display_name( 'minutes', ' ' );
 			$this->set_comments(	 'minutes', ' Minutes' );
 			$this->set_display_name( 'sunday', 'On' );
 			$this->set_comments(	 'sunday', ' Sunday' );

--- a/reason_4.0/lib/core/content_managers/image.php3
+++ b/reason_4.0/lib/core/content_managers/image.php3
@@ -94,7 +94,7 @@
 			
 			$image = $this->get_element('image');
 			$image->get_head_items($this->head_items);
-			$this->add_element('default_thumbnail', 'checkbox', 
+			$this->add_element('default_thumbnail', 'checkbox_no_label', 
 					array('description' => 'Generate thumbnail from full-size image'));
 
 			$this->change_element_type( 'width','hidden' );
@@ -110,7 +110,6 @@
 			$this->set_display_name( 'content', 'Long Caption' );
 			$this->set_display_name( 'datetime', 'Photo Taken' );
 			$this->set_display_name( 'author', 'Photographer' );
-			$this->set_display_name( 'default_thumbnail', '&nbsp;');
 
 
 			$this->set_comments( 'name', form_comment("A name for internal reference") );
@@ -131,12 +130,8 @@
 			}
 			if( $full_sizer )
 			{
-				$this->add_element( 'do_not_resize', 'checkbox', array('description' => 'Upload this image at full resolution &amp; size. (Use with caution &ndash; it is easy to accidentally upload an overly-large image.)'));
-				$this->set_display_name( 'do_not_resize', '&nbsp;');
-				$this->add_element( 'ignore_min_img_size_check', 'checkbox', array('description' => 'Ignore minimum size check and upload image of any size.'));
-				$this->set_display_name( 'ignore_min_img_size_check', '&nbsp;');
-
-
+				$this->add_element( 'do_not_resize', 'checkbox_no_label', array('description' => 'Upload this image at full resolution &amp; size. (Use with caution &ndash; it is easy to accidentally upload an overly-large image.)'));
+				$this->add_element( 'ignore_min_img_size_check', 'checkbox_no_label', array('description' => 'Ignore minimum size check and upload image of any size.'));
 			}
 
 			// Required fields


### PR DESCRIPTION
A more comprehensive solution for issue #177.

Not tackled, although still important: WYSIWYG editor field labels. Neither Loki nor TinyMCE seem to offer a clear way to associate a label with their editor iframes. A look at CKEditor suggests that it is marginally better at this.