### PR TITLE
Fix email error & add settings to Release Notes

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -22,6 +22,7 @@
       - php5-curl
       - imagemagick
       - php5-xdebug
+      - sendmail
     notify:
     - restart apache
 

--- a/reason_4.0/data/dbs/reason4.8.sql
+++ b/reason_4.0/data/dbs/reason4.8.sql
@@ -1186,7 +1186,7 @@ CREATE TABLE `ldap_cache` (
 
 LOCK TABLES `ldap_cache` WRITE;
 /*!40000 ALTER TABLE `ldap_cache` DISABLE KEYS */;
-INSERT INTO `ldap_cache` VALUES (5,'','','0000-00-00 00:00:00',''),(75393,'admin','webmaster@domain_name.domain','2015-08-14 18:38:17','admin'),(240622,'admin','webmaster@domain_name.domain','2017-03-27 14:03:23','admin'),(241409,'admin','webmaster@domain_name.domain','2015-08-14 18:38:17','admin'),(241410,'admin','webmaster@domain_name.domain','2014-01-24 14:41:55','admin');
+INSERT INTO `ldap_cache` VALUES (5,'','','0000-00-00 00:00:00',''),(75393,'admin','webmaster@example.com','2015-08-14 18:38:17','admin'),(240622,'admin','webmaster@example.com','2017-03-27 14:03:23','admin'),(241409,'admin','webmaster@example.com','2015-08-14 18:38:17','admin'),(241410,'admin','webmaster@example.com','2014-01-24 14:41:55','admin');
 /*!40000 ALTER TABLE `ldap_cache` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/release_notes/ReleaseNotes.md
+++ b/release_notes/ReleaseNotes.md
@@ -37,3 +37,20 @@ Reason CMS 4.8 Release Notes
 - Updated Snoopy in MagpieRSS to 2.0.0 - [Commit](https://github.com/reasoncms/reasoncms/commit/9fa0b060d958c4d542cbe41885e1ab8f457b9cff)
 
 ### New Settings
+ 1) REASON_DIVERT_EMAIL_TO (reason_settings)   
+   - A setting to divert email messages to a another address
+   - Defaults to off
+   - Diverted messages contain `[DIVERTED]` in subject line
+   - Applies globally for any messages sent with Tyr or Email classes
+ 2) REASON_EVENT_TICKETS_DEFAULT_CLOSE_MODIFIER (reason_settings)   
+   - A `strtotime` string that modifies the default closing time of form event ticket registration
+   - Defaults to empty string
+   - Carleton uses `-60min` to close ticket requests an hour before the event begins
+ 3) XSENDFILE_HEADER (package_settings)   
+   - A HTTP header PHP emits to instruct the webserver to deliver a file to the client at the end of the request
+   - Defaults to off/none
+   - Useful for large files and files behind authentication
+   - Used in `thor/getFormFile.php`
+   - Server modules required. More Info:
+      - Apache: https://tn123.org/mod_xsendfile/
+      - Nginx: https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/

--- a/settings/package_settings.php
+++ b/settings/package_settings.php
@@ -25,8 +25,8 @@
 // Basic information about the organization
 domain_define( 'FULL_ORGANIZATION_NAME','The Full Name of the Organization' );
 domain_define( 'SHORT_ORGANIZATION_NAME', 'Short Org Name' );
-domain_define( 'ORGANIZATION_HOME_PAGE_URI', 'http://www.domain_name.domain' );
-domain_define( 'WEBMASTER_EMAIL_ADDRESS', 'webmaster@domain_name.domain' );
+domain_define( 'ORGANIZATION_HOME_PAGE_URI', 'http://www.example.com' );
+domain_define( 'WEBMASTER_EMAIL_ADDRESS', 'webmaster@example.com' );
 domain_define( 'WEBMASTER_NAME', 'Joanne Q. Webmaster' );
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR fixes an error triggered by PHPMailer when it tried to send an email as `webmaster@domain_name.domain`. The email doesn't go out, which is ok for non-production, but it removes the error condition that exists out of the box.

I also documented new settings in the ReleaseNotes that I know about.