### PR TITLE
added instructions to rename reasoncms to reason_package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to Reason CMS!
 
 Automated Install (Using install.sh)
 ------------------------------------
-1. Move reason_package outside your web root.
+1. Rename reasoncms to reason_package and move the directory outside your web root.
 
 2. Run the install.sh script in the reason_package folder and follow instructions.
 


### PR DESCRIPTION
Little tweak to the README file to reduce confusion for people setting this up from scratch. The repo used to be called reason_package so when you cloned it the documentation would make sense. Now that it is reasoncms you have to rename the folder to reason_package when you move it outside the web tree or the install scripts won't work.